### PR TITLE
Added support for generic notification when user not connected

### DIFF
--- a/server/confluence_server.go
+++ b/server/confluence_server.go
@@ -50,7 +50,7 @@ func handleConfluenceServerWebhook(w http.ResponseWriter, r *http.Request, p *Pl
 
 		client, mmUserID, err := p.GetClientFromUserKey(instanceID, types.ID(event.UserKey))
 		if err != nil {
-			config.Mattermost.LogInfo("Error getting client for the user who triggered webhook event. Sending generic notification")
+			config.Mattermost.LogError("Error getting client for the user who triggered webhook event. Sending generic notification")
 			notification.SendGenericWHNotification(event, p.BotUserID, pluginConfig.ConfluenceURL)
 			w.Header().Set("Content-Type", "application/json")
 			ReturnStatusOK(w)

--- a/server/notification.go
+++ b/server/notification.go
@@ -62,6 +62,7 @@ func (n *notification) SendGenericWHNotification(event *serializer.ConfluenceSer
 
 	action, exists := eventActions[eventType]
 	if !exists {
+		n.client.Log.Info("Unsupported Confluence action. Generic notification will not be sent", "action", action)
 		return
 	}
 

--- a/server/notification.go
+++ b/server/notification.go
@@ -7,10 +7,11 @@ import (
 
 	"github.com/thoas/go-funk"
 
+	"github.com/mattermost/mattermost/server/public/model"
+
 	"github.com/mattermost/mattermost-plugin-confluence/server/serializer"
 	"github.com/mattermost/mattermost-plugin-confluence/server/service"
 	"github.com/mattermost/mattermost-plugin-confluence/server/util"
-	"github.com/mattermost/mattermost/server/public/model"
 )
 
 const defaultPageID = "-1"

--- a/server/notification.go
+++ b/server/notification.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/thoas/go-funk"
@@ -8,9 +10,18 @@ import (
 	"github.com/mattermost/mattermost-plugin-confluence/server/serializer"
 	"github.com/mattermost/mattermost-plugin-confluence/server/service"
 	"github.com/mattermost/mattermost-plugin-confluence/server/util"
+	"github.com/mattermost/mattermost/server/public/model"
 )
 
 const defaultPageID = "-1"
+
+var eventActions = map[string]string{
+	serializer.PageCreatedEvent:  "published",
+	serializer.PageUpdatedEvent:  "updated",
+	serializer.PageTrashedEvent:  "trashed",
+	serializer.PageRestoredEvent: "restored",
+	serializer.PageRemovedEvent:  "removed",
+}
 
 type notification struct {
 	*Plugin
@@ -39,6 +50,34 @@ func (n *notification) SendConfluenceNotifications(event serializer.ConfluenceEv
 	}
 
 	subscriptionChannelIDs := n.getNotificationChannelIDs(url, spaceKey, pageID, eventType, userID)
+	for _, channelID := range subscriptionChannelIDs {
+		post.ChannelId = channelID
+		if _, err := n.API.CreatePost(post); err != nil {
+			n.API.LogError("Unable to create Post in Mattermost", "Error", err.Error())
+		}
+	}
+}
+
+func (n *notification) SendGenericWHNotification(event *serializer.ConfluenceServerWebhookPayload, botUserID, url string) {
+	eventType := event.Event
+
+	action, exists := eventActions[eventType]
+	if !exists {
+		return
+	}
+
+	post := &model.Post{
+		UserId:  botUserID,
+		Message: fmt.Sprintf("Someone %s a page on confluence with the id %d", action, event.Page.ID),
+	}
+
+	urlPageIDSubscriptions, err := service.GetSubscriptionsByURLPageID(url, strconv.FormatInt(event.Page.ID, 10))
+	if err != nil {
+		n.API.LogError("Unable to get subscribed channels for pageID.", event.Page.ID, "Error", err.Error())
+		return
+	}
+
+	subscriptionChannelIDs := GetURLSubscriptionChannelIDs(urlPageIDSubscriptions, eventType)
 	for _, channelID := range subscriptionChannelIDs {
 		post.ChannelId = channelID
 		if _, err := n.API.CreatePost(post); err != nil {
@@ -83,13 +122,13 @@ func (n *notification) getNotificationChannelIDs(url, spaceKey, pageID, eventTyp
 		return nil
 	}
 
-	urlPageIDSubscriptionChannelIDs := GetURLSubscriptionChannelIDs(urlPageIDSubscriptions, eventType, userID)
-	urlSpaceKeySubscriptionChannelIDs := GetURLSubscriptionChannelIDs(urlSpaceKeySubscriptions, eventType, userID)
+	urlPageIDSubscriptionChannelIDs := GetURLSubscriptionChannelIDs(urlPageIDSubscriptions, eventType)
+	urlSpaceKeySubscriptionChannelIDs := GetURLSubscriptionChannelIDs(urlSpaceKeySubscriptions, eventType)
 
 	return util.Deduplicate(append(urlSpaceKeySubscriptionChannelIDs, urlPageIDSubscriptionChannelIDs...))
 }
 
-func GetURLSubscriptionChannelIDs(urlSubscriptions serializer.StringArrayMap, eventType, userID string) []string {
+func GetURLSubscriptionChannelIDs(urlSubscriptions serializer.StringArrayMap, eventType string) []string {
 	var urlSubscriptionChannelIDs []string
 
 	for channelID, events := range urlSubscriptions {
@@ -99,16 +138,4 @@ func GetURLSubscriptionChannelIDs(urlSubscriptions serializer.StringArrayMap, ev
 	}
 
 	return urlSubscriptionChannelIDs
-}
-
-func GetURLSubscriptionUserIDs(urlSubscriptions serializer.StringArrayMap, eventType string) []string {
-	var userIDs []string
-
-	for id, events := range urlSubscriptions {
-		if funk.Contains(events, eventType) {
-			userIDs = append(userIDs, id)
-		}
-	}
-
-	return userIDs
 }

--- a/server/notification.go
+++ b/server/notification.go
@@ -62,7 +62,7 @@ func (n *notification) SendGenericWHNotification(event *serializer.ConfluenceSer
 
 	action, exists := eventActions[eventType]
 	if !exists {
-		n.client.Log.Info("Unsupported Confluence action. Generic notification will not be sent", "action", action)
+		n.client.Log.Info("Unsupported Confluence action. Generic notification will not be sent", "event type", eventType)
 		return
 	}
 

--- a/server/serializer/page_subscription.go
+++ b/server/serializer/page_subscription.go
@@ -17,6 +17,8 @@ type PageSubscription struct {
 }
 
 func (ps PageSubscription) Add(s *Subscriptions) {
+	ensureSubscriptionsMapInitialized(s)
+
 	if _, valid := s.ByChannelID[ps.ChannelID]; !valid {
 		s.ByChannelID[ps.ChannelID] = make(StringSubscription)
 	}
@@ -96,4 +98,16 @@ func (ps PageSubscription) ValidateSubscription(subs *Subscriptions) error {
 		}
 	}
 	return nil
+}
+
+func ensureSubscriptionsMapInitialized(s *Subscriptions) {
+	if s.ByChannelID == nil {
+		s.ByChannelID = make(map[string]StringSubscription)
+	}
+	if s.ByURLPageID == nil {
+		s.ByURLPageID = make(map[string]StringArrayMap)
+	}
+	if s.ByURLSpaceKey == nil {
+		s.ByURLSpaceKey = make(map[string]StringArrayMap)
+	}
 }


### PR DESCRIPTION
### Summary
Added support for generic notification when the user who triggered the confluence event is not connected to Mattermost
#### Support Events
- All page-related events
#### Unsupported Events
- All comment-related events
### Screenshots
![Screenshot from 2025-01-20 18-42-14](https://github.com/user-attachments/assets/ef38c991-075b-462a-9ea1-964d2ff01a55)
