### PR TITLE
added support for admin api token

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -40,7 +40,7 @@
           "key": "AdminAPIToken",
           "display_name": "Admin API Token",
           "type": "text",
-          "help_text": "Set this [API token](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html) to get notified for comment and issue created events when the user triggering the event is not connected to Confluence.\n**Note:** API token should be created using an admin JiConfluence account. Otherwise, the notification will not be delivered.",
+          "help_text": "Set this [API token](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html) to get notified for confluence events when the user triggering the event is not connected to Confluence.\n**Note:** API token should be created using an amdin Confluence account. Otherwise, the notification will not be delivered.",
           "secret": true
         }
     ]

--- a/plugin.json
+++ b/plugin.json
@@ -40,10 +40,8 @@
           "key": "AdminAPIToken",
           "display_name": "Admin API Token",
           "type": "text",
-          "help_text": "Set this [API token](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html) to get notified for comment and issue created events when the user triggering the event is not connected to Jira. This is also used for setting up autolink in the plugin.\n **Note:** API token should be created using an admin Jira account. Otherwise, the notification will not be delivered for projects that the user cannot access and autolink will not work.",
-          "placeholder": "",
-          "secret": true,
-          "default": ""
+          "help_text": "Set this [API token](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html) to get notified for comment and issue created events when the user triggering the event is not connected to Confluence.\n**Note:** API token should be created using an admin JiConfluence account. Otherwise, the notification will not be delivered.",
+          "secret": true
         }
     ]
   }

--- a/plugin.json
+++ b/plugin.json
@@ -26,6 +26,24 @@
             "type": "generated",
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Confluence integrations."
+        },
+        {
+          "key": "EncryptionKey",
+          "display_name": "At Rest Encryption Key:",
+          "type": "generated",
+          "help_text": "The encryption key used to encrypt stored API tokens.",
+          "placeholder": "",
+          "default": null,
+          "secret": true
+        },
+        {
+          "key": "AdminAPIToken",
+          "display_name": "Admin API Token",
+          "type": "text",
+          "help_text": "Set this [API token](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html) to get notified for comment and issue created events when the user triggering the event is not connected to Jira. This is also used for setting up autolink in the plugin.\n **Note:** API token should be created using an admin Jira account. Otherwise, the notification will not be delivered for projects that the user cannot access and autolink will not work.",
+          "placeholder": "",
+          "secret": true,
+          "default": ""
         }
     ]
   }

--- a/plugin.json
+++ b/plugin.json
@@ -40,7 +40,7 @@
           "key": "AdminAPIToken",
           "display_name": "Admin API Token",
           "type": "text",
-          "help_text": "Set this [API token](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html) to get notified for confluence events when the user triggering the event is not connected to Confluence.\n**Note:** API token should be created using an amdin Confluence account. Otherwise, the notification will not be delivered.",
+          "help_text": "Set this [API token](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html) to get notified for confluence events when the user triggering the event is not connected to Confluence.\n**Note:** API token should be created using an amdin Confluence account. Otherwise, the notification will not be delivered for the spaces/pages user does not has access.",
           "secret": true
         }
     ]

--- a/server/config/main.go
+++ b/server/config/main.go
@@ -26,6 +26,7 @@ type Configuration struct {
 	ConfluenceOAuthClientID     string
 	ConfluenceOAuthClientSecret string
 	ConfluenceURL               string
+	ServerVersionGreaterthan9   bool
 }
 
 func GetConfig() *Configuration {

--- a/server/config/main.go
+++ b/server/config/main.go
@@ -20,7 +20,9 @@ var (
 )
 
 type Configuration struct {
-	Secret                      string `json:"Secret"`
+	Secret                      string `json:"secret"`
+	EncryptionKey               string `json:"encryptionKey"` // The encryption key used to encrypt stored api tokens
+	AdminAPIToken               string `json:"adminAPIToken"` // API token from Confluence Data Center
 	ConfluenceOAuthClientID     string
 	ConfluenceOAuthClientSecret string
 	ConfluenceURL               string

--- a/server/confluence_cloud.go
+++ b/server/confluence_cloud.go
@@ -17,8 +17,8 @@ var confluenceCloudWebhook = &Endpoint{
 	Execute:       handleConfluenceCloudWebhook,
 }
 
-func handleConfluenceCloudWebhook(w http.ResponseWriter, r *http.Request, _ *Plugin) {
-	config.Mattermost.LogInfo("Received confluence cloud event.")
+func handleConfluenceCloudWebhook(w http.ResponseWriter, r *http.Request, p *Plugin) {
+	p.client.Log.Info("Received confluence cloud event.")
 
 	if status, err := verifyHTTPSecret(config.GetConfig().Secret, r.FormValue("secret")); err != nil {
 		http.Error(w, err.Error(), status)

--- a/server/confluence_server.go
+++ b/server/confluence_server.go
@@ -27,14 +27,16 @@ var confluenceServerWebhook = &Endpoint{
 }
 
 func handleConfluenceServerWebhook(w http.ResponseWriter, r *http.Request, p *Plugin) {
-	config.Mattermost.LogInfo("Received confluence server event.")
+	p.client.Log.Info("Received confluence server event.")
 
 	if status, err := verifyHTTPSecret(config.GetConfig().Secret, r.FormValue("secret")); err != nil {
 		http.Error(w, err.Error(), status)
 		return
 	}
 
-	if p.serverVersionGreaterthan9 {
+	pluginConfig := config.GetConfig()
+
+	if pluginConfig.ServerVersionGreaterthan9 {
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)

--- a/server/confluence_server.go
+++ b/server/confluence_server.go
@@ -9,13 +9,14 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/mattermost/mattermost-plugin-confluence/server/config"
 	"github.com/mattermost/mattermost-plugin-confluence/server/serializer"
 	"github.com/mattermost/mattermost-plugin-confluence/server/service"
 	"github.com/mattermost/mattermost-plugin-confluence/server/store"
 	"github.com/mattermost/mattermost-plugin-confluence/server/util"
 	"github.com/mattermost/mattermost-plugin-confluence/server/util/types"
-	"github.com/pkg/errors"
 )
 
 var confluenceServerWebhook = &Endpoint{

--- a/server/confluence_server.go
+++ b/server/confluence_server.go
@@ -67,7 +67,9 @@ func handleConfluenceServerWebhook(w http.ResponseWriter, r *http.Request, p *Pl
 					}
 					event.Space.SpaceKey = spaceKey
 				}
-				eventData, err := p.GetEventDataWithAPIToken(event, pluginConfig)
+
+				var eventData *ConfluenceServerEvent
+				eventData, err = p.GetEventDataWithAPIToken(event, pluginConfig)
 				if err != nil {
 					p.client.Log.Error("error getting event data with API token", "error", err)
 					http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -158,7 +160,7 @@ func (p *Plugin) GetSpaceKeyFromSpaceIDWithAPIToken(spaceID int64, pluginConfig 
 
 		response := &apiResponse{}
 
-		body, statusCode, err := p.MakeHttpCallWithAPIToken(path)
+		body, statusCode, err := p.MakeHTTPCallWithAPIToken(path)
 		if err != nil || statusCode != http.StatusOK {
 			return "", errors.Wrapf(err, "error getting spaceKey from spaceID")
 		}
@@ -216,7 +218,7 @@ func (p *Plugin) GetCommentDataWithAPIToken(webhookPayload *serializer.Confluenc
 	commentResponse := &CommentResponse{}
 	path := fmt.Sprintf("%s%s", pluginConfig.ConfluenceURL, fmt.Sprintf(PathCommentData, strconv.FormatInt(webhookPayload.Comment.ID, 10)))
 
-	body, statusCode, err := p.MakeHttpCallWithAPIToken(path)
+	body, statusCode, err := p.MakeHTTPCallWithAPIToken(path)
 	if err != nil || statusCode != http.StatusOK {
 		return nil, err
 	}
@@ -234,7 +236,7 @@ func (p *Plugin) GetPageDataWithAPIToken(pageID int, pluginConfig *config.Config
 	pageResponse := &PageResponse{}
 	path := fmt.Sprintf("%s%s", pluginConfig.ConfluenceURL, fmt.Sprintf(PathPageData, strconv.Itoa(pageID)))
 
-	body, statusCode, err := p.MakeHttpCallWithAPIToken(path)
+	body, statusCode, err := p.MakeHTTPCallWithAPIToken(path)
 	if err != nil || statusCode != http.StatusOK {
 		return nil, err
 	}
@@ -252,7 +254,7 @@ func (p *Plugin) GetSpaceDataWithAPIToken(spaceKey string, pluginConfig *config.
 	spaceResponse := &SpaceResponse{}
 	path := fmt.Sprintf("%s%s", pluginConfig.ConfluenceURL, fmt.Sprintf(PathSpaceData, spaceKey))
 
-	body, statusCode, err := p.MakeHttpCallWithAPIToken(path)
+	body, statusCode, err := p.MakeHTTPCallWithAPIToken(path)
 	if err != nil || statusCode != http.StatusOK {
 		return nil, err
 	}
@@ -264,7 +266,7 @@ func (p *Plugin) GetSpaceDataWithAPIToken(spaceKey string, pluginConfig *config.
 	return spaceResponse, nil
 }
 
-func (p *Plugin) MakeHttpCallWithAPIToken(path string) ([]byte, int, error) {
+func (p *Plugin) MakeHTTPCallWithAPIToken(path string) ([]byte, int, error) {
 	httpClient := &http.Client{}
 	req, err := http.NewRequest(http.MethodGet, path, nil)
 	if err != nil {

--- a/server/flow.go
+++ b/server/flow.go
@@ -235,7 +235,10 @@ func (fm *FlowManager) stepServerVersionQuestion() flow.Step {
 			Name:  "Yes",
 			Color: flow.ColorPrimary,
 			OnClick: func(f *flow.Flow) (flow.Name, flow.State, error) {
-				fm.plugin.serverVersionGreaterthan9 = true
+				pluginConfig := config.GetConfig()
+				pluginConfig.ServerVersionGreaterthan9 = true
+				config.SetConfig(pluginConfig)
+
 				return stepCSversionGreaterthan9, nil, nil
 			},
 		}).
@@ -243,6 +246,10 @@ func (fm *FlowManager) stepServerVersionQuestion() flow.Step {
 			Name:  "No",
 			Color: flow.ColorDefault,
 			OnClick: func(f *flow.Flow) (flow.Name, flow.State, error) {
+				pluginConfig := config.GetConfig()
+				pluginConfig.ServerVersionGreaterthan9 = false
+				config.SetConfig(pluginConfig)
+
 				return stepCSversionLessthan9, nil, nil
 			},
 		})

--- a/server/flow.go
+++ b/server/flow.go
@@ -264,8 +264,7 @@ func (fm *FlowManager) stepCSversionGreaterthan9() flow.Step {
 				fmt.Sprintf("   - **Redirect URL**: `%s`\n", fm.GetRedirectURL()) +
 				"   - **Application Permissions**: `Admin`\n" +
 				"   Select **Continue**.\n" +
-				"5. Copy the `clientID` and `clientSecret` from **Settings**, and paste them into the modal in Mattermost which can be opened by using the `/confluence config add` slash command.\n" +
-				"6. In Mattermost, use the `/confluence connect` slash command to connect your Mattermost account with your Confluence account\n",
+				"5. Copy the `clientID` and `clientSecret` from **Settings**\n",
 		).
 		WithButton(continueButton(stepOAuthInput))
 }

--- a/server/notification.go
+++ b/server/notification.go
@@ -34,7 +34,7 @@ func (p *Plugin) getNotification() *notification {
 	}
 }
 
-func (n *notification) SendConfluenceNotifications(event serializer.ConfluenceEventV2, eventType, botUserID, userID string) {
+func (n *notification) SendConfluenceNotifications(event serializer.ConfluenceEventV2, eventType, botUserID string) {
 	url := event.GetURL()
 	if url == "" {
 		return
@@ -50,7 +50,7 @@ func (n *notification) SendConfluenceNotifications(event serializer.ConfluenceEv
 		return
 	}
 
-	subscriptionChannelIDs := n.getNotificationChannelIDs(url, spaceKey, pageID, eventType, userID)
+	subscriptionChannelIDs := n.getNotificationChannelIDs(url, spaceKey, pageID, eventType)
 	for _, channelID := range subscriptionChannelIDs {
 		post.ChannelId = channelID
 		if _, err := n.API.CreatePost(post); err != nil {
@@ -111,7 +111,7 @@ func (n *notification) extractSpaceKeyAndPageID(event serializer.ConfluenceEvent
 	return spaceKey, pageID
 }
 
-func (n *notification) getNotificationChannelIDs(url, spaceKey, pageID, eventType, userID string) []string {
+func (n *notification) getNotificationChannelIDs(url, spaceKey, pageID, eventType string) []string {
 	urlSpaceKeySubscriptions, err := service.GetSubscriptionsByURLSpaceKey(url, spaceKey)
 	if err != nil {
 		n.API.LogError("Unable to get subscribed channels for spaceKey.", "Error", err.Error())

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -41,8 +41,6 @@ type Plugin struct {
 
 	pluginVersion string
 
-	serverVersionGreaterthan9 bool
-
 	telemetryClient telemetry.Client
 	tracker         telemetry.Tracker
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -118,8 +118,8 @@ func (p *Plugin) OnConfigurationChange() error {
 
 		encryptionKey := configuration.EncryptionKey
 		if encryptionKey == "" {
-			p.client.Log.Warn("Encryption key required to encrypt admin API token")
-			return errors.New("failed to encrypt admin token. Encryption key not generated")
+			p.client.Log.Warn("Encryption key is required to encrypt admin API token")
+			return errors.New("failed to encrypt admin token. Encryption key is not generated")
 		}
 
 		encryptedAdminAPIToken, err := encrypt(jsonBytes, []byte(encryptionKey))

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -112,10 +112,6 @@ func (p *Plugin) OnConfigurationChange() error {
 	}
 
 	if configuration.AdminAPIToken != "" {
-		fmt.Println("\n\n\n\n\n")
-		fmt.Println("configuration.AdminAPIToken ", configuration.AdminAPIToken)
-		fmt.Println("configuration.EncryptionKey ", configuration.EncryptionKey)
-		fmt.Println("\n\n\n\n\n")
 		jsonBytes, err := json.Marshal(configuration.AdminAPIToken)
 		if err != nil {
 			p.client.Log.Warn("Error marshaling the admin API token", "error", err.Error())


### PR DESCRIPTION
### Summary
Added support to use admin API token to make API call when user is not connected

### Testing step
- Add the admin API token  to plugin config
- Trigger an event on confluence using a user which is not connected on MM